### PR TITLE
Permit unpacking of complex types

### DIFF
--- a/R/bind.R
+++ b/R/bind.R
@@ -30,8 +30,6 @@ bind <- function(...) {
   structure(list(bindings = bindings, scope = scope), class = "bindings")
 }
 
-.unpack <- function(x) unname(unlist(x, use.names = FALSE))[1]
-
 #' Bind a `bind` object to values.
 #'
 #' Used to bind variables in the local scope to values, typically returned from
@@ -71,7 +69,7 @@ bind <- function(...) {
       variable <- bindings$bindings[[i]]
       if (!is.name(variable)) stop(paste0("Positional variables cannot be expressions ",
                                           deparse(variable), "\n"))
-      val <- .unpack(value[i])
+      val <- value[[i]]
       assign(as.character(variable), val, envir = bindings$scope)
 
     } else {

--- a/tests/testthat/test_bindings.R
+++ b/tests/testthat/test_bindings.R
@@ -1,5 +1,18 @@
 context("Bindings")
 
+test_that("we can return complex objects", {
+  f <- function() {
+    fit <- glm(qsec ~ ., data=mtcars)
+    return(list(fit, mtcars, nrow(mtcars)))
+  }
+
+  bind(model, df, size) %<-% f()
+  expect_is(model, "lm")
+  expect_is(model, "glm")
+  expect_is(df, "data.frame")
+  expect_equal(size, 32)      # mtcars sample is known to be 32 rows
+})
+
 test_that("we can bind values by position", {
   f <- function(x, y) c(x, y)
   g <- function(x, y) list(x, y)
@@ -13,6 +26,7 @@ test_that("we can bind values by position", {
   expect_equal(a, 1)
   expect_equal(b, 2)
   rm(a) ; rm(b)
+
 })
 
 test_that("we get an error if we try to bind too many variables", {


### PR DESCRIPTION
Not sure if this creates more problems than solves, but it replaces `.unpack` with a call to `value[[i]]`